### PR TITLE
Fix bug where window tool bar button does not show some buttons

### DIFF
--- a/window-tool-bar.el
+++ b/window-tool-bar.el
@@ -301,6 +301,12 @@ MENU-ITEM is a menu item to convert.  See info node `(elisp)Tool Bar'."
                 (vert-only (plist-get plist :vert-only))
                 image-start
                 image-end)
+	   ;; Ensure STR is never the empty string, which wouldn't
+	   ;; display at all when concat'ed together.
+	   (when (string-empty-p str)
+	     (setf str (symbol-name binding)
+		   len (length str)))
+
            ;; Depending on style, Images can be displayed to the
            ;; left, to the right, or in place of the text
            (pcase-exhaustive (window-tool-bar--style)


### PR DESCRIPTION
The window tool bar did not show buttons with a label set to "". Use the symbol name of the binding in this case. This fixes #31.