### PR TITLE
Revert "Disabling package-lint check"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version: [27.1, 27.2, 28.1, 28.2, 29.1, 29.2, 29.3, 29.4, 30.1, 30.2]
-        # TODO: Revert back to just the melpa check.  Blocked by
-        # https://github.com/purcell/package-lint/issues/281
-        check: [load-file, byte-compile, checkdoc]
     steps:
       - uses: purcell/setup-emacs@master
         with:
@@ -25,6 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: leotaku/elisp-check@master
         with:
-          check: ${{ matrix.check }}
+          check: melpa
           file: '*.el'
           warnings_as_errors: true


### PR DESCRIPTION
This reverts commit a59ec495cbc2458c33db0dcf779757706e42e9a6.

Tooling issue https://github.com/purcell/package-lint/issues/281 is now fixed.